### PR TITLE
The old Javascript would bug because jQuery is not an existent dependancy anymore

### DIFF
--- a/avalanche/base.html
+++ b/avalanche/base.html
@@ -181,6 +181,6 @@
       </tr>
     </table>
   </div>
-  <script>$().landslide();</script>
+  <script>main();</script>
 </body>
 </html>


### PR DESCRIPTION
My fix was based on landslide's default theme.

The slides in the examples folder now works as expected. fixes issue #12 