### PR TITLE
Clean up example configs

### DIFF
--- a/example_presentation/presentation-black.cfg
+++ b/example_presentation/presentation-black.cfg
@@ -5,6 +5,5 @@ destination = ./example-black.html
 css         = ../custom_css/pygments/monokai.css 
               ../custom_css/black.css 
               custom.css
-relative    = True
 embed       = True
 linenos     = no

--- a/example_presentation/presentation-pm-nonotes.cfg
+++ b/example_presentation/presentation-pm-nonotes.cfg
@@ -5,6 +5,5 @@ destination = ./example-pm-nonotes.html
 css         = ../custom_css/pygments/monokai.css 
               ../custom_css/pm-nonotes.css 
               custom.css
-relative    = True
 embed       = True
 linenos     = no

--- a/example_presentation/presentation.cfg
+++ b/example_presentation/presentation.cfg
@@ -1,9 +1,16 @@
 [landslide]
-theme       = ../avalanche
 source      = example.md
 destination = ./example.html
-css         = ../custom_css/pygments/default.css  ; source code highlighting
+
+; directory where the theme is defined (not repository root)
+theme       = ../avalanche
+
+; include syntax highlighting css, then presentation-specific css
+css         = ../custom_css/pygments/default.css
               custom.css
-relative    = True
+
+; embed JS & CSS into output file for standalone html output
 embed       = True
+
+; no line numbers in code view
 linenos     = no


### PR DESCRIPTION
Relative is not needed since we're using `embed=True`.  It was harmless, but I'm brand new to landslide and was using the example to wrap my head around things, so I figured best to include only what's necessary.

Moved+added comments for the basic example (presentation.cfg)